### PR TITLE
Add dummy login and home pages

### DIFF
--- a/app/home.tsx
+++ b/app/home.tsx
@@ -1,0 +1,32 @@
+import { Stack, useRouter } from 'expo-router';
+import { StyleSheet, Button } from 'react-native';
+
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function HomeScreen() {
+  const router = useRouter();
+  return (
+    <ThemedView style={styles.container}>
+      <Stack.Screen options={{ title: 'Home' }} />
+      <ThemedText type="title" style={styles.title}>Home</ThemedText>
+      <ThemedText style={styles.text}>Welcome to the home page.</ThemedText>
+      <Button title="Log out" onPress={() => router.replace('/')} />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  title: {
+    marginBottom: 10,
+  },
+  text: {
+    marginBottom: 20,
+  },
+});

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,56 @@
+import { Stack, useRouter } from 'expo-router';
+import { useState } from 'react';
+import { StyleSheet, TextInput, Button } from 'react-native';
+
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function LoginScreen() {
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleLogin = () => {
+    router.replace('/home');
+  };
+
+  return (
+    <ThemedView style={styles.container}>
+      <Stack.Screen options={{ title: 'Login' }} />
+      <ThemedText type="title" style={styles.title}>Login</ThemedText>
+      <TextInput
+        style={styles.input}
+        placeholder="Username"
+        value={username}
+        onChangeText={setUsername}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Password"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+      />
+      <Button title="Login" onPress={handleLogin} />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'center',
+  },
+  title: {
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 10,
+    marginBottom: 15,
+    borderRadius: 4,
+  },
+});


### PR DESCRIPTION
## Summary
- add simple login screen at `app/index.tsx`
- add placeholder home screen at `app/home.tsx`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e7352b85c832e9e658445f5ef51b5